### PR TITLE
Fixed issue #123. Corrected typo in PineTree.cs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 SneakyTactician  <SneakyTactician@outlook.com>
 
+
+#### Bugs
+*Fixed PineTree class property Name's value
+*Fixed mined stones not disappering
+
 ---
 
 ## [Version 0.1.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,5 @@
 SneakyTactician  <SneakyTactician@outlook.com>
 
-
-#### Bugs
-*Fixed PineTree class property Name's value
-*Fixed mined stones not disappering
-
 ---
 
 ## [Version 0.1.2]
@@ -27,6 +22,8 @@ SneakyTactician  <SneakyTactician@outlook.com>
 *Zooming out now supported
 
 #### Bugs
+*Fixed PineTree class property Name's value
+*Fixed mined stones not disappering
 
 ---
 

--- a/MagicalLife.sln
+++ b/MagicalLife.sln
@@ -42,7 +42,7 @@ Global
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9096A50A-058B-40F4-80A7-3C4D8725B658}.Debug|Any CPU.ActiveCfg = Debug|x86
+		{9096A50A-058B-40F4-80A7-3C4D8725B658}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{9096A50A-058B-40F4-80A7-3C4D8725B658}.Debug|x64.ActiveCfg = Debug|x64
 		{9096A50A-058B-40F4-80A7-3C4D8725B658}.Debug|x86.ActiveCfg = Debug|x86
 		{9096A50A-058B-40F4-80A7-3C4D8725B658}.Debug|x86.Build.0 = Debug|x86

--- a/MagicalLifeAPIStandard/World/Resources/PineTree.cs
+++ b/MagicalLifeAPIStandard/World/Resources/PineTree.cs
@@ -15,7 +15,7 @@ namespace MagicalLifeAPI.World.Resources
     [ProtoContract]
     public class PineTree : TreeBase
     {
-        private static readonly string Name = "Maple Tree";
+        private static readonly string Name = "Pine Tree";
         public static readonly int Durabilitie = 20;
 
         public static readonly int XOffset = Tile.GetTileSize().X / -2;

--- a/MagicalLifeAPIStandard/World/Resources/Rock.cs
+++ b/MagicalLifeAPIStandard/World/Resources/Rock.cs
@@ -15,6 +15,8 @@ namespace MagicalLifeAPI.World.Resources
     [ProtoContract]
     public class Rock : RockBase
     {
+        private AbstractVisual visual;
+
         public static readonly string StoneName = "Stone";
 
         public override AbstractHarvestable HarvestingBehavior { get; set; }
@@ -25,10 +27,12 @@ namespace MagicalLifeAPI.World.Resources
             {
                 new StoneRubble(this.Durability)
             }, SoundsTable.PickaxeHit, "");
+            visual = new StaticTexture(AssetManager.NameToIndex[this.GetRandomStoneTexture()], RenderLayer.Stone);
         }
 
         public Rock()
         {
+            visual = new StaticTexture(AssetManager.NameToIndex[this.GetRandomStoneTexture()], RenderLayer.Stone);
         }
 
         public override string GetUnconnectedTexture()
@@ -40,7 +44,8 @@ namespace MagicalLifeAPI.World.Resources
         {
             List<AbstractVisual> visuals = new List<AbstractVisual>
             {
-                new StaticTexture(AssetManager.NameToIndex[this.GetRandomStoneTexture()], RenderLayer.Stone)
+                //new StaticTexture(AssetManager.NameToIndex[this.GetRandomStoneTexture()], RenderLayer.Stone)
+                visual
             };
 
             return visuals;


### PR DESCRIPTION
Fixed issue #123 (Mined stones doesn't disappear) and corrected a typo in PineTree Name property. Prease review my changes in CHANGELOG.md also.
Ty.
